### PR TITLE
Pass an access token for private repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ You can set the environment variable in three ways:
 PRISMIC_TOKEN=XXXX prismic-apollo-introspect --repo <repoId> --out <path>
 ```
 
-## In your `.bash_profile/.bashrc/.zshrc`
+## In your Bash/ZSH config
 
-A more permanent (and secure) way to set the environment variable is in your Bash/Zsh config file.
+A more permanent (and secure) way to set the environment variable is in your `.bash_profile/.bashrc/.zshrc`.
 
 ```sh
 export PRISMIC_TOKEN="XXXX"
@@ -72,7 +72,7 @@ export PRISMIC_TOKEN="XXXX"
 
 ## In an `.env` file
 
-If you need to set several environment variables for several projects, an [`.env`](https://nodejs.dev/learn/how-to-read-environment-variables-from-nodejs) file at the root of your project file is a convenient way to manage them. To pass `.env` variables to this utility, use the [`env-cmd` NPM package](https://github.com/toddbluhm/env-cmd):
+If you need to set environment variables for several projects, an [`.env`](https://nodejs.dev/learn/how-to-read-environment-variables-from-nodejs) file at the project root is a convenient way to manage them. To pass `.env` variables to this utility, use the [`env-cmd` NPM package](https://github.com/toddbluhm/env-cmd):
 
 Install the package:
 

--- a/README.md
+++ b/README.md
@@ -49,3 +49,44 @@ You should re-run the introspection generator every time your content model chan
   }
 }
 ```
+
+## Private repos
+
+If your Prismic repo requires an access token, set a `PRISMIC_TOKEN` environment variable. The utility will use it to connect to your repo.
+
+You can set the environment variable in three ways:
+
+## Manually
+
+```sh
+PRISMIC_TOKEN=XXXX prismic-apollo-introspect --repo <repoId> --out <path>
+```
+
+## In your `.bash_profile/.bashrc/.zshrc`
+
+A more permanent (and secure) way to set the environment variable is in your Bash/Zsh config file.
+
+```sh
+export PRISMIC_TOKEN="XXXX"
+```
+
+## In an `.env` file
+
+If you need to set several environment variables for several projects, an [`.env`](https://nodejs.dev/learn/how-to-read-environment-variables-from-nodejs) file at the root of your project file is a convenient way to manage them. To pass `.env` variables to this utility, use the [`env-cmd` NPM package](https://github.com/toddbluhm/env-cmd):
+
+Install the package:
+
+```sh
+npm i -D env-cmd
+```
+
+Then prepend it to your NPM script:
+
+```js
+{
+  "scripts": {
+    "predevelop": "env-cmd prismic-apollo-introspect --repo <repoId> --out <path>",
+    "develop": "..."
+  }
+}
+```

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-
 import fetch from 'node-fetch';
 import { program } from 'commander';
 import symbols from 'log-symbols';
@@ -8,19 +7,18 @@ import fs from 'fs';
 program
   .option('-r, --repo <repoId>', 'prismic repository ID')
   .option('-o, --out <path>', 'Path to output file')
-  .option('-t, --token <accessToken>', 'Path to text file with your access token')
   .parse();
 
-const { repo, out, token } = program.opts();
+const { repo, out } = program.opts();
+const token = process.env.PRISMIC_TOKEN;
 
 let prismicApi = `https://${repo}.cdn.prismic.io/api`,
   fragmentsQuery = `https://${repo}.cdn.prismic.io/graphql?query=%7B%20__schema%20%7B%20types%20%7B%20kind%20name%20possibleTypes%20%7B%20name%20%7D%20%7D%20%7D%20%7D`,
   headers = {};
 
 if (token) {
-  const tokenString = fs.readFileSync(token, 'utf-8');
-  prismicApi += `?access_token=${tokenString}`;
-  headers['authorization'] = `Token ${tokenString}`;
+  prismicApi += `?access_token=${token}`;
+  headers['authorization'] = `Token ${token}`;
 }
 
 async function generateFragmentTypes() {
@@ -33,9 +31,8 @@ async function generateFragmentTypes() {
 
   headers['prismic-ref'] = ref.ref;
 
-  const result = await fetch(fragmentsQuery, {
-    headers
-  }).then((result) => result.json());
+  const result = await fetch(fragmentsQuery, { headers })
+    .then((result) => result.json());
 
   const filteredData = result.data.__schema.types.filter(
     (type) => type.possibleTypes !== null


### PR DESCRIPTION
Thanks so much for making this npm package! It was a huge help for me when I ran into the Introspection issue while trying to fetch my slices. Unfortunately, my Prismic repo is private and requires an access token. I took a stab at modifying your script so that it can pass an optional token to the endpoints - appreciate your thoughts.

- It accepts a path to a text file (e.g. `./.prismic-token`) containing nothing but your token string.
- I'm not super familiar with the `command` lib - hopefully I set up the option right...
- I tested this locally with my own Prismic repo and it worked, but I haven't tested much beyond that.